### PR TITLE
Support click event on custom rows

### DIFF
--- a/ac.js
+++ b/ac.js
@@ -328,7 +328,7 @@ AC.prototype.click = function click(e) {
       return;
     }
 
-    if (parent.className === AC.CLASS.ROW) {
+    if (parent.className.match(AC.CLASS.ROW)) {
       var id = parseInt(parent.getAttribute('data-rid'), 10);
       if (!isNaN(id)) {
         rowid = id;


### PR DESCRIPTION
When using a custom rowFn, the class name of the row includes an extra space: ' ac-row'. This means that the className here will _never_ exactly equal 'ac-row', which breaks the click handling. It should use `match` instead, since the user might want to customize the row class.
