### PR TITLE
Pass along click/keypress events to triggerFn callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ where:
 * `requestFn` is the function that allows full customization of a request behavior. It takes the user input string and should update `this.results` with the desired result and call `this.render()` to update the autocomplete. If this function is provided, both `urlFn` and `resultFn` will be ignored.
 * `resultFn` is the function that processes the returned results, in case you have some custom format. It takes the raw HTTP response, and returns a list of autocomplete results. If the response is already a list of results, you do not need to specify this function.
 * `rowFn` is the function that takes the data of a row to render the row in the DOM. If it is not provided, autocomplete will generate the rows automatically.
-* `triggerFn` is the function called when the user clicks on an autocomplete row. The result associated with the row will be passed in as the parameter.
+* `triggerFn` is the function called when the user clicks on an autocomplete row. The result associated with the row will be passed in as the first parameter. The second parameter is the triggering event (click or keypress) so you can prevent event bubbling or process it in other ways.
 * `anchorEl` is the element to position the autocomplete against, in case you don't want it to be positioned below the input element.
 
 If you would like to use the default row rendering function, you can have a primary text label and an optional secondary text label. The default keys to them are `title` and `subtitle`, i.e.:

--- a/ac.js
+++ b/ac.js
@@ -27,7 +27,9 @@
  *     representing the row. If this function is not provided, the widget will
  *     render the rows with the default `createRow` function.
  * @param {Function} triggerFn The optional function called when an
- *     autocomplete result is selected.
+ *     autocomplete result is selected. First argument is the row object,
+ *     second argument is an event object for the user action (click or
+ *     keypress).
  * @param {Element} anchorEl The optional DOM element to attach the autocomplete
  *     to. If not provided, the autocomplete is attached to the input element.
  * @constructor
@@ -304,7 +306,7 @@ AC.prototype.keydown = function keydown(e) {
       break;
     case AC.KEYCODE.ENTER:
       if (this.selectedIndex > -1) {
-        this.trigger();
+        this.trigger(e);
       }
       break;
     case AC.KEYCODE.ESC:
@@ -395,7 +397,7 @@ AC.prototype.click = function click(e) {
 
   if (rowid > -1) {
     this.selectedIndex = rowid;
-    this.trigger(rowid);
+    this.trigger(e);
   } else {
     this.unmount();
   }
@@ -404,13 +406,15 @@ AC.prototype.click = function click(e) {
 /**
  * Triggers the selected item. This function sets the value of the input,
  * calls the provided trigger function, and unmounts the autocomplete.
+ *
+ * @param {Event} event The triggering event.
  */
-AC.prototype.trigger = function trigger() {
+AC.prototype.trigger = function trigger(event) {
   this.value = this.results[this.selectedIndex][this.primaryTextKey];
   this.inputEl.value = this.value;
   this.inputEl.blur();
   if (this.triggerFn) {
-    this.triggerFn(this.results[this.selectedIndex]);
+    this.triggerFn(this.results[this.selectedIndex], event);
   }
   this.unmount();
 };


### PR DESCRIPTION
This makes it easier to manage event bubbling, e.g., if the
trigger action causes a change in focus within a form.